### PR TITLE
Read messages from tendermint is complex and slow

### DIFF
--- a/abci/encoding.py
+++ b/abci/encoding.py
@@ -1,9 +1,5 @@
 from io import BytesIO
 
-# Codes
-NODATA = 1
-FRAGDATA = 2
-OK = 3
 
 def encode_varint(number):
     # Shift to int64
@@ -45,9 +41,8 @@ def write_message(message):
 
 
 def read_messages(reader, message):
-    """ read the message based on the varintself.
-    Returns: (value, code) based on results
-    """
+    """Return an interator of the messages found in
+    the `reader` (BytesIO instance)."""
 
     while True:
         try:

--- a/abci/encoding.py
+++ b/abci/encoding.py
@@ -43,21 +43,24 @@ def write_message(message):
     buffer.write(bz)
     return buffer.getvalue()
 
-def read_message(reader, message):
+
+def read_messages(reader, message):
     """ read the message based on the varintself.
     Returns: (value, code) based on results
     """
-    current_position = reader.tell()
-    len64 = decode_varint(reader)
-    length = len64 >> 1
-    slice = reader.read(length)
 
-    if len(slice) == 0:
-        return None, NODATA
+    while True:
+        try:
+            length = decode_varint(reader) >> 1
+        except EOFError:
+            return
 
-    if len(slice) < length:
-        return current_position, FRAGDATA
+        data = reader.read(length)
 
-    m = message()
-    m.ParseFromString(slice)
-    return m, OK
+        if len(data) < length:
+            return
+
+        m = message()
+        m.ParseFromString(data)
+
+        yield m

--- a/abci/server.py
+++ b/abci/server.py
@@ -16,7 +16,7 @@ import gevent, signal
 from gevent.event import Event
 from gevent.server import StreamServer
 
-from .encoding import read_message, write_message, NODATA, FRAGDATA, OK
+from .encoding import read_messages, write_message, NODATA, FRAGDATA, OK
 from .messages import *
 from .types_pb2 import Request
 from .utils import get_logger
@@ -101,10 +101,8 @@ def decode_varint(value):
 def read_varint_stream(sock):
     sz = decode_varint(sock.recv(1))
     data = b''
-    print(f'SIZE: {sz}')
     while sz:
         buf = sock.recv(sz)
-        print(f'BUFFER: {buf}')
         if not buf:
             raise ValueError("Buffer receive truncated")
         data += buf
@@ -149,38 +147,30 @@ class ABCIServer(object):
     def __handle_connection(self, socket, address):
         log.info(' ... connection from Tendermint: {}:{} ...'.format(address[0], address[1]))
         data = BytesIO()
-        carry_forward = b''
+        last_pos = 0
+
         while True:
-            # Read max 100MB of transaction from the socket
-            # NOTE: It doesn't make sense to have transactions greater than
-            # 100MB. This assumption simplifies the read and deocding logic
-            inbound = socket.recv(104857600)
-            msg_length = len(carry_forward) + len(inbound)
-            data.write(carry_forward)
+            # Create a new buffer every time there is the possibility.
+            # This avoids having a never ending buffer.
+            if last_pos == data.tell():
+                data = BytesIO()
+                last_pos = 0
+
+            inbound = socket.recv(1024 * 10) # 10KB
             data.write(inbound)
 
-            data.seek(0)
-            carry_forward = b''
-            if not data or msg_length == 0:
-                return
-            try:
-                while data.tell() < msg_length:
-                    initial_data_tell = data.tell()
-                    result, code = read_message(data, Request)
-                    if code == NODATA:
-                        data.seek(initial_data_tell)
-                        carry_forward = data.read(msg_length - data.tell())
-                        break
-                    if code == FRAGDATA:
-                        data.seek(result)
-                        carry_forward = data.read(msg_length)
-                        break
-                    req_type = result.WhichOneof("value")
-                    response = self.protocol.process(req_type, result)
-                    socket.send(response)
-            except:
-                log.error(" Server Error: {}".format(sys.exc_info()[1]))
+            if not len(inbound):
+                break
 
-            data.seek(0)
-            data.truncate()
+            # Before reading the messages from the buffer, position the
+            # cursor at the end of the last read message.
+            data.seek(last_pos)
+            messages = read_messages(data, Request)
+
+            for message in messages:
+                req_type = message.WhichOneof('value')
+                response = self.protocol.process(req_type, message)
+                socket.send(response)
+                last_pos = data.tell()
+
         socket.close()

--- a/abci/server.py
+++ b/abci/server.py
@@ -16,7 +16,7 @@ import gevent, signal
 from gevent.event import Event
 from gevent.server import StreamServer
 
-from .encoding import read_messages, write_message, NODATA, FRAGDATA, OK
+from .encoding import read_messages, write_message
 from .messages import *
 from .types_pb2 import Request
 from .utils import get_logger
@@ -156,7 +156,7 @@ class ABCIServer(object):
                 data = BytesIO()
                 last_pos = 0
 
-            inbound = socket.recv(1024 * 10) # 10KB
+            inbound = socket.recv(1024 * 8) # 8KB
             data.write(inbound)
 
             if not len(inbound):

--- a/tests/test_protocol_handler.py
+++ b/tests/test_protocol_handler.py
@@ -25,44 +25,38 @@ def test_handler():
 
     r = to_response_echo('hello')
     data = p.process('echo', r)
-    res, err  = read_message(BytesIO(data), types.Response)
-    assert res
-    assert 'echo' == res.WhichOneof("value")
-    assert res.echo.message == 'hello'
+    message = next(read_messages(BytesIO(data), types.Response))
+    assert 'echo' == message.WhichOneof("value")
+    assert message.echo.message == 'hello'
 
     data = p.process('flush', None)
-    res, err  = read_message(BytesIO(data), types.Response)
-    assert res
-    assert 'flush' == res.WhichOneof("value")
+    message = next(read_messages(BytesIO(data), types.Response))
+    assert 'flush' == message.WhichOneof("value")
 
     data = p.process('info', None)
-    res, err  = read_message(BytesIO(data), types.Response)
-    assert res
-    assert 'info' == res.WhichOneof("value")
-    assert res.info.data == 'hellothere'
+    message = next(read_messages(BytesIO(data), types.Response))
+    assert 'info' == message.WhichOneof("value")
+    assert message.info.data == 'hellothere'
 
     r = to_request_deliver_tx(b'0x1234')
     data = p.process('deliver_tx', r)
-    res, err  = read_message(BytesIO(data), types.Response)
-    assert res
-    assert 'deliver_tx' == res.WhichOneof("value")
-    assert res.deliver_tx.code == 0
-    assert res.deliver_tx.data == b'0x1234'
+    message = next(read_messages(BytesIO(data), types.Response))
+    assert 'deliver_tx' == message.WhichOneof("value")
+    assert message.deliver_tx.code == 0
+    assert message.deliver_tx.data == b'0x1234'
 
     r = to_request_check_tx(b'0x1234')
     data = p.process('check_tx', r)
-    res, err  = read_message(BytesIO(data), types.Response)
-    assert res
-    assert 'check_tx' == res.WhichOneof("value")
-    assert res.check_tx.code == 0
-    assert res.check_tx.data == b'0x1234'
+    message = next(read_messages(BytesIO(data), types.Response))
+    assert 'check_tx' == message.WhichOneof("value")
+    assert message.check_tx.code == 0
+    assert message.check_tx.data == b'0x1234'
 
     r = to_request_query(data=b'name')
     data = p.process('query', r)
-    res, err  = read_message(BytesIO(data), types.Response)
-    assert res
-    assert 'query' == res.WhichOneof("value")
-    assert res.query.key == b'name'
-    assert res.query.value == b'dave'
-    assert res.query.code == 0
-    assert res.query.proof == b'0x12'
+    message = next(read_messages(BytesIO(data), types.Response))
+    assert 'query' == message.WhichOneof("value")
+    assert message.query.key == b'name'
+    assert message.query.value == b'dave'
+    assert message.query.code == 0
+    assert message.query.proof == b'0x12'

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -8,14 +8,14 @@ def test_encoding_decoding():
     echo = to_request_echo('hello')
     raw = write_message(echo)
     buffer = BytesIO(raw)
-    req, _ = read_message(buffer, types.Request)
-    assert 'echo' == req.WhichOneof("value")
+    message = next(read_messages(buffer, types.Request))
+    assert 'echo' == message.WhichOneof("value")
 
     info = to_request_info()
     raw1 = write_message(info)
     buffer1 = BytesIO(raw1)
-    req1, _ = read_message(buffer1, types.Request)
-    assert 'info' == req1.WhichOneof("value")
+    message = next(read_messages(buffer1, types.Request))
+    assert 'info' == message.WhichOneof("value")
 
 def test_flow():
     from io import BytesIO
@@ -23,10 +23,10 @@ def test_flow():
     inbound = b'\x14"\x08\n\x060.16.0\x04\x1a\x00'
     data = BytesIO(inbound)
 
-    req_type,_  = read_message(data, types.Request)
-    assert 'info' == req_type.WhichOneof("value")
+    message = next(read_messages(data, types.Request))
+    assert 'info' == message.WhichOneof("value")
 
-    req_type2, _  = read_message(data, types.Request)
-    assert 'flush' == req_type2.WhichOneof("value")
+    message = next(read_messages(data, types.Request))
+    assert 'flush' == message.WhichOneof("value")
 
     assert data.read() == b''


### PR DESCRIPTION
Solution: simplify the code and allow a smaller buffer when reading the socket.